### PR TITLE
Added feature to allow manually setting SDK versions

### DIFF
--- a/src/templates/gatewaySettings.twig
+++ b/src/templates/gatewaySettings.twig
@@ -80,3 +80,28 @@
 }) }}
 {% endfor %}
 {# {% endif %} #}
+
+<hr>
+<a class="fieldtoggle" data-target="advanced">{{ "Advanced"|t('app') }}</a>
+<div id="advanced" class="hidden">
+    {{ autosuggestField({
+        label: 'Drop-in UI SDK Version'|t('commerce-braintree'),
+        instructions: 'SDK version used for drop-in UI on site front end. Most recent versions are listed in the [GitHub repository](https://github.com/braintree/braintree-web-drop-in/tags). If left blank, version will default to `1.21.0`.',
+        id: 'dropinUiSdkVersion',
+        class: 'ltr',
+        name: 'dropinUiSdkVersion',
+        value: gateway.dropinUiSdkVersion,
+        errors: gateway.getErrors('dropinUiSdkVersion'),
+        suggestEnvVars: true
+    }) }}
+    {{ autosuggestField({
+        label: 'Client SDK Version'|t('commerce-braintree'),
+        instructions: 'SDK version used for hosted fields in the control panel. Most recent versions are listed in the [GitHub repository](https://github.com/braintree/braintree-web/tags). If left blank, version will default to `3.52.0`.',
+        id: 'clientSdkVersion',
+        class: 'ltr',
+        name: 'clientSdkVersion',
+        value: gateway.clientSdkVersion,
+        errors: gateway.getErrors('clientSdkVersion'),
+        suggestEnvVars: true
+    }) }}
+</div>


### PR DESCRIPTION
We've been having some issues with customers being unable to checkout using the drop-in UI. It seems to be happening before nonce creation, which makes it hard to trace. After contacting Braintree support, they pointed out we were using older SDKs and recommended we start by updating those. Because the SDKs are updated fairly frequently, I figured it would be good to have a way to designate a specific SDK version rather than you guys having to update the plugin every time. Thanks for your consideration!