### PR TITLE
Removed calls to deprecated Order::getUser()

### DIFF
--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -333,21 +333,16 @@ class Gateway extends BaseGateway
 				'options' => ['submitForSettlement' => false],
 			];
 
-			if ($order->user) {
-				if ($this->getCustomer($order->user)) {
-					$data['customerId'] = $order->user->uid;
-				} else {
-					$data['customer'] = [
-						'firstName' => $order->user->firstName,
-						'lastName' => $order->user->lastName,
-						'email' => $order->email,
-					];
-				}
-			} else {
-				$data['customer'] = [
-					'email' => $order->email,
-				];
-			}
+            $user = $order->getCustomer();
+            if ($this->getCustomer($user)) {
+                $data['customerId'] = $user->uid;
+            } else {
+                $data['customer'] = [
+                    'firstName' => $user->firstName,
+                    'lastName' => $user->lastName,
+                    'email' => $user->email,
+                ];
+            }
 
 			// deviceData
 
@@ -465,21 +460,16 @@ class Gateway extends BaseGateway
 				'options' => ['submitForSettlement' => true],
 			];
 
-			if ($order->user) {
-				if ($this->getCustomer($order->user)) {
-					$data['customerId'] = $order->user->uid;
-				} else {
-					$data['customer'] = [
-						'firstName' => $order->user->firstName,
-						'lastName' => $order->user->lastName,
-						'email' => $order->email,
-					];
-				}
-			} else {
-				$data['customer'] = [
-					'email' => $order->email,
-				];
-			}
+            $user = $order->getCustomer();
+            if ($this->getCustomer($user)) {
+                $data['customerId'] = $user->uid;
+            } else {
+                $data['customer'] = [
+                    'firstName' => $user->firstName,
+                    'lastName' => $user->lastName,
+                    'email' => $user->email,
+                ];
+            }
 
 			// deviceData
 


### PR DESCRIPTION
In Commerce 4, all customers are now represented by a `User` element as outlined in [the documentation](https://craftcms.com/docs/commerce/4.x/upgrading.html#customer-%E2%86%92-user-transition). As a result, `Order::getUser()` has been deprecated and `getCustomer()` should be used instead.

There were several instances of `$order->user` called causing the `getUser()` deprecation error. I removed these calls and restructured the logic to reflect the fact that customers are now `User` elements.