### PR TITLE
Fixed several JS errors

### DIFF
--- a/src/assetbundles/dropinui/dist/js/DropinUi.js
+++ b/src/assetbundles/dropinui/dist/js/DropinUi.js
@@ -21,163 +21,170 @@
 
 	function init($) {
 		document.querySelectorAll('form').forEach(function($form) {
+			var $dropinUi = $form.querySelector('[data-id="dropInUi"]');
+
+			if (!$dropinUi) {
+				return;
+			}
+
 			var $token = $form.querySelector('[name*="gatewayToken"]'),
 				$nonce = $form.querySelector('[name*="nonce"]'),
 				amount = $form.querySelector('[name*="amount"]').value,
 				currency = $form.querySelector('[name*="currency"]').value,
 				email = $form.querySelector('[name*="email"]').value,
 				address = $form.querySelector('[name*="address"]').value,
-				$dropinUi = $form.querySelector('[data-id="dropInUi"]'),
-				$submit = $form.querySelector('button[type="submit"]');
+				$submit = $form.querySelector('button[type="submit"], input[type="submit"]');
 
-			if ($dropinUi) {
-				$submit.dataset.text = $submit.innerText;
-				if ($submit.dataset.loading) {
-					$submit.dataset.text = $submit.dataset.loading;
+			$submit.dataset.text = $submit.innerText;
+			if ($submit.dataset.loading) {
+				$submit.dataset.text = $submit.dataset.loading;
+			}
+
+			var options = {
+				authorization: $token.value,
+				container: $dropinUi,
+				locale: $dropinUi.dataset.locale,
+				vaultManager: $dropinUi.dataset.manage,
+				card: {
+					cardholderName: {
+						required: true
+					},
+					vault: {
+						vaultCard: true,
+						allowVaultCardOverride: true
+					}
 				}
+			};
+			if ($dropinUi.dataset.translations != '') {
+				options.translations = JSON.parse($dropinUi.dataset.translations);
+			}
 
-				var options = {
-					authorization: $token.value,
-					container: $dropinUi,
-					locale: $dropinUi.dataset.locale,
-					vaultManager: $dropinUi.dataset.manage,
-					card: {
-						cardholderName: {
-							required: true
-						},
-						vault: {
-							vaultCard: true,
-							allowVaultCardOverride: true
+			if (Boolean($dropinUi.dataset.subscription) != true) {
+				options.paypal = {
+					flow: 'checkout',
+					env: $dropinUi.dataset.sandbox ? 'sandbox' : 'production',
+					amount: amount,
+					currency: currency,
+					buttonStyle: {
+						color: 'blue',
+						shape: 'rect',
+						size: 'responsive',
+						label: 'paypal'
+					}
+				};
+
+				options.applePay = {
+					displayName: $dropinUi.dataset.name,
+					paymentRequest: {
+						total: {
+							label: $dropinUi.dataset.name,
+							amount: amount
 						}
 					}
 				};
-				if ($dropinUi.dataset.translations != '') {
-					options.translations = JSON.parse($dropinUi.dataset.translations);
-				}
 
-				if (Boolean($dropinUi.dataset.subscription) != true) {
-					options.paypal = {
-						flow: 'checkout',
-						env: $dropinUi.dataset.sandbox ? 'sandbox' : 'production',
-						amount: amount,
-						currency: currency,
-						buttonStyle: {
-							color: 'blue',
-							shape: 'rect',
-							size: 'responsive',
-							label: 'paypal'
-						}
-					};
-
-					options.applePay = {
-						displayName: $dropinUi.dataset.name,
-						paymentRequest: {
-							total: {
-								label: $dropinUi.dataset.name,
-								amount: amount
-							}
-						}
-					};
-
-					options.googlePay = {
-						merchantId: $dropinUi.dataset.googlePayId,
-						googlePayVersion: 2,
-						transactionInfo: {
-							countryCode: address ? JSON.parse(address).countryCodeAlpha2 : '',
-							currencyCode: currency,
-							totalPriceStatus: 'FINAL',
-							totalPrice: amount
-						}
-					};
-				} else {
-					options.card.vault.allowVaultCardOverride = false;
-				}
-
-				if ($dropinUi.dataset.threedsecure) {
-					options.threeDSecure = true;
-				}
-
-				braintree.dropin.create(options, function(err, dropinInstance) {
-					if (err) {
-						console.error(err);
-						if (window.braintreeError) {
-							window.braintreeError(err);
-						}
-						return;
+				options.googlePay = {
+					merchantId: $dropinUi.dataset.googlePayId,
+					googlePayVersion: 2,
+					transactionInfo: {
+						countryCode: address ? JSON.parse(address).countryCodeAlpha2 : '',
+						currencyCode: currency,
+						totalPriceStatus: 'FINAL',
+						totalPrice: amount
 					}
-
-					if (dropinInstance.isPaymentMethodRequestable()) {
-						reset($submit);
-					}
-					//need for vault
-					dropinInstance.on('paymentMethodRequestable', function(e) {
-						reset($submit);
-					});
-					dropinInstance.on('noPaymentMethodRequestable', function(e) {
-						processing($submit);
-					});
-					dropinInstance.on('paymentOptionSelected', function(e) {
-						//$submit.prop('disabled', false);
-					});
-
-					$form.addEventListener(
-						'submit',
-						{
-							dropinInstance: dropinInstance,
-							threeDSecure: $dropinUi.dataset.threedsecure,
-							options: {
-								threeDSecure: {
-									amount: amount,
-									email: email,
-									billingAddress: address ? JSON.parse(address) : address
-								}
-							}
-						},
-						formSubmit
-					);
-				});
-			}
-		});
-	}
-
-	function formSubmit(e) {
-		e.preventDefault();
-		//console.log(e)
-		var dropinInstance = e.data.dropinInstance,
-			$form = e.currentTarget,
-			threeDSecure = e.data.threeDSecure,
-			$submit = $form.querySelector('button[type="submit"]');
-		processing($submit);
-
-		dropinInstance.requestPaymentMethod(threeDSecure ? e.data.options : {}, function(err, payload) {
-			if (err) {
-				console.error(err);
-				if (window.braintreeError) {
-					window.braintreeError(err);
-				}
-				reset($submit);
-				return;
-			}
-			//console.log(payload);
-			if ((payload.liabilityShiftPossible && payload.liabilityShifted) || !payload.liabilityShiftPossible || payload.type !== 'CreditCard' || !threeDSecure) {
-				processing($submit);
-				$form.querySelector('input[name*=nonce]').val(payload.nonce);
-				$form.removeEventListener('submit', formSubmit);
-				$form.submit();
+				};
 			} else {
-				if (window.braintreeError) {
-					window.braintreeError('3ds failed');
-				}
-				//dropinInstance.clearSelectedPaymentMethod();
-				reset($submit);
-				//$submit.prop('disabled', true);
+				options.card.vault.allowVaultCardOverride = false;
 			}
+
+			if ($dropinUi.dataset.threedsecure) {
+				options.threeDSecure = true;
+			}
+
+			braintree.dropin.create(options, function(err, dropinInstance) {
+				if (err) {
+					console.error(err);
+					if (window.braintreeError) {
+						window.braintreeError(err);
+					}
+					return;
+				}
+
+				if (dropinInstance.isPaymentMethodRequestable()) {
+					reset($submit);
+				}
+				//need for vault
+				dropinInstance.on('paymentMethodRequestable', function(e) {
+					reset($submit);
+				});
+				dropinInstance.on('noPaymentMethodRequestable', function(e) {
+					processing($submit);
+				});
+				dropinInstance.on('paymentOptionSelected', function(e) {
+					//$submit.prop('disabled', false);
+				});
+
+				$form.addEventListener(
+					'submit',
+					formSubmit({
+						dropinInstance: dropinInstance,
+						threeDSecure: $dropinUi.dataset.threedsecure,
+						options: {
+							threeDSecure: {
+								amount: amount,
+								email: email,
+								billingAddress: address ? JSON.parse(address) : address
+							}
+						}
+					})
+				);
+			});
 		});
 	}
+
+	function formSubmit(data) {
+		return function submitHandler(e) {
+			e.preventDefault();
+			// console.log(data);
+			// console.log(e);
+			var dropinInstance = data.dropinInstance,
+				$form = e.currentTarget,
+				threeDSecure = data.threeDSecure,
+				$submit = $form.querySelector('button[type="submit"], input[type="submit"]');
+			processing($submit);
+
+			dropinInstance.requestPaymentMethod(threeDSecure ? data.options : {}, function(err, payload) {
+				if (err) {
+					console.error(err);
+					if (window.braintreeError) {
+						window.braintreeError(err);
+					}
+					reset($submit);
+					return;
+				}
+				//console.log(payload);
+				if ((payload.liabilityShiftPossible && payload.liabilityShifted) || !payload.liabilityShiftPossible || payload.type !== 'CreditCard' || !threeDSecure) {
+					processing($submit);
+					$form.querySelector('input[name*=nonce]').value = payload.nonce;
+					$form.removeEventListener('submit', formSubmit);
+					$form.submit();
+				} else {
+					if (window.braintreeError) {
+						window.braintreeError('3ds failed');
+					}
+					//dropinInstance.clearSelectedPaymentMethod();
+					reset($submit);
+					//$submit.prop('disabled', true);
+				}
+			});
+		}
+	}
+
 	function reset($button) {
 		$button.disabled = false;
 		$button.innerText = $button.dataset.text;
 	}
+
 	function processing($button) {
 		$button.disabled = true;
 		if ($button.dataset.processing) {


### PR DESCRIPTION
I encountered several JS errors with the Drop-in UI that I've addressed here.

* I realized I could resolve #47 without passing a gateway handle. This is addressed in lines 24–29. If no drop-in UI element is found in the form, the function returns null to prevent trying to access a value on a null element.
* A couple instances of `querySelector('button[type="submit"]')` could result in errors if an `input` element was used to submit the form instead of a `button`. Updated the selectors to address this.
* On line 127, `addEventListener()` is not a direct replacement for jQuery `on()`, and because the parameters weren't formatted correctly, the event wasn't triggering. Because `addEventListener()` doesn't pass data the way `on()` does, it's necessary to pass the data another way. One way is using currying, which I implemented on line 127, seen in `formSubmit()`.
* Replaced a remaining call to jQuery `val()` with `.value` on line 168.